### PR TITLE
Add toggle shortcut and menu item

### DIFF
--- a/Plash/Intents.swift
+++ b/Plash/Intents.swift
@@ -58,6 +58,70 @@ struct RemoveWebsitesItent: AppIntent, CustomIntentMigratedAppIntent {
 	}
 }
 
+struct ToggleCurrentleWebsiteIntent: AppIntent, CustomIntentMigratedAppIntent {
+	enum Action: String, AppEnum, CaseDisplayRepresentable {
+		case toggle
+		case turn
+
+		static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Mode")
+
+		static var caseDisplayRepresentations: [ToggleCurrentleWebsiteIntent.Action: DisplayRepresentation] = [
+			.toggle: DisplayRepresentation(stringLiteral: "Toggle"),
+			.turn: DisplayRepresentation(stringLiteral: "Turn")
+		]
+	}
+
+	static let intentClassName = "ToggleWebsiteIntent"
+
+	static let title: LocalizedStringResource = "Toggle Plash"
+
+	static let description = IntentDescription("Toggle Plash.")
+
+	@Parameter(title: "Mode", default: .toggle)
+	var action: Action
+
+	@Parameter(title: "On/Off")
+	var setTo: Bool
+
+	static var parameterSummary: some ParameterSummary {
+		Switch(\.$action) {
+			Case(Action.toggle) {
+				Summary("\(\.$action) Plash")
+			}
+			Case(Action.turn) {
+				Summary("\(\.$action) Plash \(\.$setTo)")
+			}
+			DefaultCase {
+				Summary("\(\.$action) Plash")
+			}
+		}
+	}
+
+	func perform() async throws -> some IntentResult {
+		switch action {
+		case .toggle:
+			await toggle()
+		case .turn:
+			await turn(setTo)
+		}
+		return .result()
+	}
+
+	@MainActor
+	func toggle() {
+		Task {
+			AppState.shared.isEnabled.toggle()
+		}
+	}
+	
+	@MainActor
+	func turn(_ setTo: Bool) {
+		Task {
+			AppState.shared.isEnabled = setTo
+		}
+	}
+}
+
 @available(macOS, deprecated: 13, message: "Replaced by the “Find Website” action.")
 struct GetWebsitesIntent: AppIntent, CustomIntentMigratedAppIntent {
 	static let intentClassName = "GetWebsitesIntent"

--- a/Plash/Menus.swift
+++ b/Plash/Menus.swift
@@ -166,6 +166,14 @@ extension AppState {
 	func updateMenu() {
 		menu.removeAllItems()
 
+		menu.addCallbackItem(
+			"Toggle \(AppState.shared.isEnabled ? "Off" : "On")"
+		) {
+			AppState.shared.isEnabled.toggle()
+		}
+			.setShortcut(for: .reload)
+		menu.addSeparator()
+
 		if isEnabled {
 			addWebsiteItems()
 		} else {


### PR DESCRIPTION
Hi!
I hope contributions are still welcome!

This pr introduces two things: 
- A toggle shortcut intent that can toggle or set an on/off state for Plash
- A menu item to toggle Plash (which would resolve #35 

Things I would love some feedback on: 
1. The wording of the menu item. `Toggle on/off` vs `Turn on/off`? Any other ideas? 
1. Currently, when toggled off, the standard message for the off-state is shown (see screenshot below). 
Would a more diverse status system be of interest here with different reasons, at least for the off-state? 
<img width="296" alt="Screenshot 2023-06-21 at 19 37 51" src="https://github.com/sindresorhus/Plash/assets/39119695/83dc1264-0eae-4746-a2ec-fce6fd762050">
